### PR TITLE
[Merged by Bors] - Don't `clippy` lint for module name repetitions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,6 @@ script:
     -D clippy::mem_forget
     -D clippy::missing_docs_in_private_items
     -D clippy::missing_errors_doc
-    -D clippy::module_name_repetitions
     -D clippy::multiple_inherent_impl
     -D clippy::mut_mut
     -D clippy::needless_continue


### PR DESCRIPTION
This lint would become extremely annoying in the future due to how the
project structure will work, particularly with Amethyst's `State`s and
`System`s.