### PR TITLE
[Merged by Bors] - Enfoce guidelines outlined in `CONTRIBUTING.md`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,11 +10,7 @@ mod states;
 use amethyst::{
     core::transform::TransformBundle,
     prelude::*,
-    renderer::{
-        plugins::{RenderFlat2D, RenderToWindow},
-        types::DefaultBackend,
-        RenderingBundle,
-    },
+    renderer::{types::DefaultBackend, RenderFlat2D, RenderToWindow, RenderingBundle},
     utils,
     LoggerConfig,
 };

--- a/src/states/mod.rs
+++ b/src/states/mod.rs
@@ -1,5 +1,7 @@
 //! The collection of possible game states
 
+mod ingame;
+
 /// Contains common types used when implememnting a [`State`]
 ///
 /// [`State`]: https://docs.amethyst.rs/stable/amethyst/trait.State.html
@@ -8,5 +10,3 @@ mod state_prelude {
 }
 
 pub(crate) use ingame::Ingame;
-
-mod ingame;


### PR DESCRIPTION
This was far from exhaustive; the main thing done was reordering a
single `mod` import. However, a `use` declaration was changed to reflect
a preference not shown in `CONTRIBUTING.md`: `use` an item at the
soonest point it comes into scope (which happens from re-exporting).