### PR TITLE
Don't use squash merge strategy for bors

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,2 +1,1 @@
 status = ["continuous-integration/travis-ci/push"]
-use_squash_merge = true


### PR DESCRIPTION
As ugly as merge commits may look to me, they have the following major
benefits:

 - Preserving commit signatures (if applicable)

 - Preserving detailed commit messages

It should be noted that both of these are preserved in GitHub's
"history" through past PR's. However, these things should really be held
in the commit history for portability reasons (e.g. mirrors) and the
commit history is meant to hold them anyway.