### PR TITLE
Set codegen-units to 1 in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ no-slow-safety-checks = ["amethyst/no-slow-safety-checks"]
 
 [profile.release]
 lto = true
+codegen-units = 1


### PR DESCRIPTION
It's generally a good idea to optimize a release binary as much as possible, the most common drawback being compile times. However, based on some _very_ loose testing, decreasing codegen-units doesn't appear to increase compile times significantly for us (and may actually _decrease_ them right now).