### PR TITLE
Cleanup stylistic inconsistencies

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,6 @@ use amethyst::{
     controls::{CursorHideSystemDesc, MouseFocusUpdateSystemDesc},
     core::transform::TransformBundle,
     input::InputBundle,
-    prelude::*,
     renderer::{
         types::DefaultBackend,
         RenderDebugLines,
@@ -23,11 +22,14 @@ use amethyst::{
         RenderingBundle,
     },
     utils,
+    Application,
+    GameDataBuilder,
     LoggerConfig,
 };
 
 use crate::{
     input::IngameBindings,
+    states::Ingame,
     systems::{CameraRotationSystemDesc, FlyMovementSystem},
 };
 
@@ -35,22 +37,21 @@ fn main() -> amethyst::Result<()> {
     amethyst::start_logger(LoggerConfig::default());
 
     let app_root = utils::application_root_dir()?;
-
-    let assets_dir = app_root.join("assets");
     let config_dir = app_root.join("config");
-    let display_config_path = config_dir.join("display.ron");
-    let input_config_path = config_dir.join("ingame_bindings.ron");
 
     let game_data = GameDataBuilder::default()
         .with_bundle(
-            InputBundle::<IngameBindings>::new().with_bindings_from_file(input_config_path)?,
+            InputBundle::<IngameBindings>::new()
+                .with_bindings_from_file(config_dir.join("ingame_bindings.ron"))?,
         )?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(RenderDebugLines::default())
                 .with_plugin(RenderShaded3D::default())
                 .with_plugin(RenderSkybox::default())
-                .with_plugin(RenderToWindow::from_config_path(display_config_path)?),
+                .with_plugin(RenderToWindow::from_config_path(
+                    config_dir.join("display_config.ron"),
+                )?),
         )?
         .with_bundle(TransformBundle::new())?
         .with(FlyMovementSystem, "fly_movement", &[])
@@ -62,7 +63,7 @@ fn main() -> amethyst::Result<()> {
             &["mouse_focus"],
         );
 
-    let mut game = Application::new(assets_dir, states::Ingame, game_data)?;
+    let mut game = Application::new(app_root.join("assets"), Ingame, game_data)?;
     game.run();
 
     Ok(())

--- a/src/states/ingame.rs
+++ b/src/states/ingame.rs
@@ -6,8 +6,11 @@ use amethyst::{
         math::{Point3, Translation3, UnitQuaternion, Vector3},
         transform::Transform,
     },
-    prelude::*,
+    ecs::{Builder, WorldExt},
     renderer::{debug_drawing::DebugLinesComponent, palette::Srgba, Camera},
+    GameData,
+    SimpleState,
+    StateData,
 };
 use lazy_static::lazy_static;
 use static_assertions::const_assert_eq;


### PR DESCRIPTION
This change mainly consists of the main three fixes:

 - Reduce unnecessary variables

 - Use idiomatic `use` paths

 - Stop using prelude modules

Unnecessary variables can reduce readability and increase stack/heap allocations within reason, idiomatic `use` paths are stated as enforced in CODESTYLE.md, and prelude modules are generally less expressive than manually importing their items. The first and last of these three changes may be added to CODESTYLE.md in the future, but for now implicit enforcement is good enough.